### PR TITLE
Require django < 2.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ CLASSIFIERS = [
     'Topic :: Software Development',
 ]
 install_requires = [
-    'django >= 1.9.0',
+    'django >= 1.9.0, < 2.0',
     'mako >= 1.0.0',
 ]
 


### PR DESCRIPTION
In order avoid ImportError since RegexURLPattern doesn't exist in django 2.0