### PR TITLE
Added cli to DMP to help create projects and apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ django.mo
 .#*
 __pycache__
 _build
+Pipfile
+*.egg-info/

--- a/django_mako_plus/cli.py
+++ b/django_mako_plus/cli.py
@@ -1,0 +1,54 @@
+import subprocess as sp
+
+import pkg_resources
+import crayons
+import click
+
+
+@click.group()
+def main():
+    """The django-mako-plus cli."""
+    pass
+
+
+@main.group()
+def new():
+    """Create a new project or app."""
+    pass
+
+
+@new.command()
+@click.argument('name')
+def project(name):
+    """Create a new django-mako-plus project."""
+    click.echo('Creating new project ' + crayons.magenta(name, bold=True))
+
+    template_path = pkg_resources.resource_filename('django_mako_plus', 'project_template')
+
+    sp.check_call(
+        'python3 -m django startproject --template={path} {name}'.format(path=template_path, name=name),
+        shell=True
+    )
+
+    click.echo(crayons.green('Successfully created ') + crayons.magenta(name, bold=True))
+
+
+@new.command()
+@click.argument('name')
+def app(name):
+    """Create a new django-mako-plus app."""
+    click.echo('Creating new app ' + crayons.magenta(name, bold=True))
+
+    template_path = pkg_resources.resource_filename('django_mako_plus', 'app_template')
+
+    sp.check_call(
+        'python3 manage.py startapp --template={path} --extension=py,htm,html {name}'.format(path=template_path,
+                                                                                             name=name),
+        shell=True
+    )
+
+    click.echo(crayons.green('successfully created ' + crayons.magenta(name, bold=True)))
+
+
+if __name__ == '__main__':
+    main()

--- a/django_mako_plus/cli.py
+++ b/django_mako_plus/cli.py
@@ -37,7 +37,7 @@ def project(name):
 @click.argument('name')
 def app(name):
     """Create a new django-mako-plus app."""
-    click.echo('Creating new app ' + crayons.magenta(name, bold=True))
+    click.echo('Creating new app     ' + crayons.magenta(name, bold=True))
 
     template_path = pkg_resources.resource_filename('django_mako_plus', 'app_template')
 
@@ -47,7 +47,7 @@ def app(name):
         shell=True
     )
 
-    click.echo(crayons.green('successfully created ' + crayons.magenta(name, bold=True)))
+    click.echo(crayons.green('Successfully created ' + crayons.magenta(name, bold=True)))
 
 
 if __name__ == '__main__':

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,9 +43,9 @@ Quick Start
     pip3 install django-mako-plus
 
     # create a new project with a 'homepage' app
-    python3 -m django startproject --template=http://cdn.rawgit.com/doconix/django-mako-plus/master/project_template.zip mysite
+    dmp new project mysite
     cd mysite
-    python3 manage.py startapp --template=http://cdn.rawgit.com/doconix/django-mako-plus/master/app_template.zip --extension=py,htm,html homepage
+    dmp new app homepage
 
     # open mysite/settings.py and append 'homepage' to the INSTALLED_APPS list
     INSTALLED_APPS = [

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,7 +62,7 @@ Don't forget to migrate to synchronize your database and create a superuser:
 Create a DMP-Style App
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Change to your project directory in the terminal/console, then create a new Django-Mako-Plus.
+Change to your project directory in the terminal/console, then create a new Django-Mako-Plus app.
 
 As with creating a DMP project, there are two ways to create a DMP app. One can use the shortcut provided with the DMP command-line-interface,
 or use django's ``manage.py startapp`` command with a ``--template`` option.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,8 +33,14 @@ Note that on Windows machines, ``pip3`` may need to be replaced with ``pip``:
 
 Create a Django project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+There are two ways you can start a new DMP project. The first is to use the command-line interface that comes bundled
+with django-mako-plus.
 
-Create a Django project, and specify that you want a DMP-style project layout:
+::
+
+    dmp new project mysite
+
+The previous command is just a shortcut to the following method of using django to create a new project, specifying that you want a DMP-style project layout:
 
 ::
 
@@ -56,10 +62,15 @@ Don't forget to migrate to synchronize your database and create a superuser:
 Create a DMP-Style App
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Change to your project directory in the terminal/console, then create a new Django-Mako-Plus app with the following:
+Change to your project directory in the terminal/console, then create a new Django-Mako-Plus.
+
+As with creating a DMP project, there are two ways to create a DMP app. One can use the shortcut provided with the DMP command-line-interface,
+or use django's ``manage.py startapp`` command with a ``--template`` option.
 
 .. code:: python
 
+    dmp new app homepage
+    # or alternatively...
     python3 manage.py startapp --template=http://cdn.rawgit.com/doconix/django-mako-plus/master/app_template.zip --extension=py,htm,html homepage
 
 **After** the new ``homepage`` app is created, add your new app to the ``INSTALLED_APPS`` list in ``settings.py``:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ CLASSIFIERS = [
 install_requires = [
     'django >= 1.9.0',
     'mako >= 1.0.0',
+    'click >= 6.7',
+    'crayons >= 0.1.2',
 ]
 
 
@@ -95,5 +97,6 @@ setup(
 #  data_files=data_files,
   install_requires=install_requires,
   classifiers=CLASSIFIERS,
+  entry_points={'console_scripts': ['dmp=django_mako_plus.cli:main']},
   license='Apache 2.0',
 )


### PR DESCRIPTION
I thought it would be helpful since it's so common to create new projects and apps to have a couple of handy shortcuts with DMP.

`dmp new project [name]`

and 

`dmp new app [name]`

Additionally, the templates used will be the ones on the local fileystem that are included in the DMP package, so using the shortcuts won't necessitate pulling the info from github.