### PR TITLE
Update deploy_static.rst

### DIFF
--- a/docs/deploy_static.rst
+++ b/docs/deploy_static.rst
@@ -87,7 +87,7 @@ When you deploy to a web server, run ``dmp collectstatic`` to collect your stati
 ::
 
     python3 manage.py collectstatic
-    python3 manage.py dmp_collectstatic --overwrite
+    python3 manage.py dmp_collectstatic --overwrite (uses python3 manage.py dmp collectstatic instead in the newer versions)
 
 Point your web server (Apache, Nginx, IIS, etc.) to serve this folder directly to browsers. For example, in Nginx, you'd set the following:
 


### PR DESCRIPTION
Just commenting in that manage.py uses dmp collectstatic instead of dmp_collectstatic in the newer versions on dmp. (No underscore as dmp is it's own manage.py subcommand now in the later versions unless you changed this back in the very latest versions)

We love this tool. Thanks for making this.