### PR TITLE
crash fix when using a custom dmp_path regex

### DIFF
--- a/django_mako_plus/router/resolver.py
+++ b/django_mako_plus/router/resolver.py
@@ -193,7 +193,7 @@ class PagePattern(URLPattern):
                     match.kwargs.pop('dmp_app', None) or self.dmp.options['DEFAULT_APP'],
                     match.kwargs.pop('dmp_page', None) or self.dmp.options['DEFAULT_PAGE'],
                     match.kwargs.pop('dmp_function', None) or 'process_request',
-                    match.kwargs.pop('dmp_urlparams', '').strip(),
+                    (match.kwargs.pop('dmp_urlparams', None) or '').strip(),
                 )
                 if VERSION < (2, 2):
                     return ResolverMatch(


### PR DESCRIPTION
- This prevents a crash if the dmp_path regex captures a None value for
the dmp_urlparams matching group. A regex like:

^(org\.(?P<orgslug>[_a-zA-Z0-9\-]+)/)?(?P<dmp_page>[_a-zA-Z0-9\-]+)(\.?P<dmp_function>[_a-zA-Z0-9\.\-]+)?/(?P<dmp_urlparams>.+?)?$

for a path like:
org.agency-1/agent_dashboard/

would result in the crash.